### PR TITLE
serve flask via uwsgi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN apt-get update && apt-get install -y python3-dev gcc libc-dev
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ./main.py ./
+COPY . .
 
 EXPOSE 5000
 
-ENTRYPOINT ["python"]
-CMD ["./main.py"]
+CMD ["uwsgi", "main.ini"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM python:3.6-slim
 
+# uswgi fails to install without these dependencies
+RUN apt-get update && apt-get install -y python3-dev gcc libc-dev
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./main.py ./
 
-EXPOSE 5000 
+EXPOSE 5000
 
 ENTRYPOINT ["python"]
 CMD ["./main.py"]

--- a/main.ini
+++ b/main.ini
@@ -1,0 +1,11 @@
+[uwsgi]
+wsgi-file = main.py
+callable = app
+processes = 4
+threads = 2
+http = 0.0.0.0:5000   ; Needed to answer HTTP requests
+http-processes = 4    
+buffer-size = 65535   ; Default buffer too low
+master = true
+vacuum = true         ; Try to remove all of the generated files/sockets upon exit.
+die-on-term = true    ; exit on SIGTERM

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask==1.1.1
 pandas==1.0.1
+uwsgi==2.0.18


### PR DESCRIPTION
To remove "Warning use only in development" we are going to serve the flask application with uwsgi as recommended